### PR TITLE
merge

### DIFF
--- a/frontend/src/components/studySession/ContinueStudyingSection.tsx
+++ b/frontend/src/components/studySession/ContinueStudyingSection.tsx
@@ -1,17 +1,36 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { StudySessionColors } from "../../styles/colors";
 import StudyCard from "./StudyCard";
+import { getSessions } from "../../utils/sessionStorage";
+import type { StudySession } from "../../types/session";
 
 const ContinueStudyingSection: React.FC = () => {
+  const [sessions, setSessions] = useState<StudySession[]>([]);
+
+  useEffect(() => {
+    const all = getSessions()
+      .filter((s) => !s.isCompleted)
+      .sort((a, b) => b.lastAccessedAt - a.lastAccessedAt)
+      .slice(0, 4);
+    setSessions(all);
+  }, []);
+
   return (
     <div style={styles.section}>
       <h2 style={styles.sectionTitle}>Continue Studying</h2>
       <p style={styles.subtitle}>Recently accessed workspaces</p>
 
-      <div style={styles.cardGrid}>
-        <StudyCard />
-        <StudyCard />
-      </div>
+      {sessions.length === 0 ? (
+        <p style={styles.emptyText}>
+          No sessions yet. Create one above to get started!
+        </p>
+      ) : (
+        <div style={styles.cardGrid}>
+          {sessions.map((session) => (
+            <StudyCard key={session.id} session={session} />
+          ))}
+        </div>
+      )}
     </div>
   );
 };
@@ -33,6 +52,12 @@ const styles: { [key: string]: React.CSSProperties } = {
   cardGrid: {
     display: "flex",
     gap: "20px",
+    flexWrap: "wrap",
+  },
+  emptyText: {
+    fontSize: "14px",
+    color: StudySessionColors.subtitle,
+    marginTop: "8px",
   },
 };
 

--- a/frontend/src/components/studySession/GenerateStudySessionCard.tsx
+++ b/frontend/src/components/studySession/GenerateStudySessionCard.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useState } from "react";
 import { StudySessionColors } from "../../styles/colors";
 import { useNavigate } from "react-router-dom";
+import { createSessionId, saveSession } from "../../utils/sessionStorage";
+import type { StudySession } from "../../types/session";
 
 const GenerateStudySessionCard: React.FC = () => {
   const navigate = useNavigate();
@@ -57,11 +59,21 @@ const GenerateStudySessionCard: React.FC = () => {
     }
 
     setShowError(false);
+
+    const now = Date.now();
+    const session: StudySession = {
+      id: createSessionId(),
+      title: sessionName.trim() || "Untitled Session",
+      studyMaterial: text,
+      outputs: { summary: "", quiz: "", flashcards: "", keypoints: "" },
+      createdAt: now,
+      lastAccessedAt: now,
+      isCompleted: false,
+    };
+    saveSession(session);
+
     navigate("/study-workspace", {
-      state: {
-        studyMaterial: text,
-        sessionTitle: sessionName || "Untitled Session",
-      },
+      state: { sessionId: session.id },
     });
   };
 

--- a/frontend/src/components/studySession/StudyCard.tsx
+++ b/frontend/src/components/studySession/StudyCard.tsx
@@ -1,11 +1,25 @@
 import React from "react";
 import { StudySessionColors } from "../../styles/colors";
+import { useNavigate } from "react-router-dom";
+import type { StudySession } from "../../types/session";
+import { formatLastAccessed } from "../../utils/sessionStorage";
 
-const StudyCard: React.FC = () => {
+interface StudyCardProps {
+  session: StudySession;
+}
+
+const StudyCard: React.FC<StudyCardProps> = ({ session }) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate("/study-workspace", { state: { sessionId: session.id } });
+  };
+
   return (
     <button
       type="button"
       style={styles.studyCard}
+      onClick={handleClick}
       onMouseEnter={(e) => {
         e.currentTarget.style.transform = "translateY(-3px)";
         e.currentTarget.style.boxShadow = StudySessionColors.shadowLg;
@@ -17,8 +31,10 @@ const StudyCard: React.FC = () => {
         e.currentTarget.style.borderColor = StudySessionColors.studyCardBorder;
       }}
     >
-      <p style={styles.studyTitle}>SOEN 357 — Lecture 4: UX design process</p>
-      <p style={styles.studySubtitle}>Last accessed · Today</p>
+      <p style={styles.studyTitle}>{session.title}</p>
+      <p style={styles.studySubtitle}>
+        Last accessed · {formatLastAccessed(session.lastAccessedAt)}
+      </p>
     </button>
   );
 };

--- a/frontend/src/pages/MyLibrary.tsx
+++ b/frontend/src/pages/MyLibrary.tsx
@@ -1,15 +1,70 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Sidebar from "../components/layout/Sidebar";
+import { StudySessionColors } from "../styles/colors";
+import StudyCard from "../components/studySession/StudyCard";
+import { getSessions } from "../utils/sessionStorage";
+import type { StudySession } from "../types/session";
 
 const MyLibrary: React.FC = () => {
+  const [sessions, setSessions] = useState<StudySession[]>([]);
+
+  useEffect(() => {
+    const all = getSessions()
+      .filter((s) => s.isCompleted)
+      .sort((a, b) => b.lastAccessedAt - a.lastAccessedAt);
+    setSessions(all);
+  }, []);
+
   return (
     <div style={{ display: "flex", minHeight: "100vh" }}>
       <Sidebar />
-      <div style={{ padding: 40, textAlign: "center" }}></div>
-      <h1>My Library</h1>
-      <p>This is your library. Content coming soon!</p>
+      <div style={styles.main}>
+        <h1 style={styles.title}>My Library</h1>
+        <p style={styles.subtitle}>Your completed study sessions</p>
+
+        {sessions.length === 0 ? (
+          <p style={styles.emptyText}>
+            No completed sessions yet. Finish a session in the workspace to see it here!
+          </p>
+        ) : (
+          <div style={styles.cardGrid}>
+            {sessions.map((session) => (
+              <StudyCard key={session.id} session={session} />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
+};
+
+const styles: { [key: string]: React.CSSProperties } = {
+  main: {
+    flex: 1,
+    padding: "40px",
+    background: `linear-gradient(135deg, ${StudySessionColors.pageGradientStart}, ${StudySessionColors.pageGradientEnd})`,
+  },
+  title: {
+    fontSize: "32px",
+    marginBottom: "8px",
+    color: StudySessionColors.title,
+  },
+  subtitle: {
+    fontSize: "16px",
+    color: StudySessionColors.subtitle,
+    marginBottom: "32px",
+    marginTop: 0,
+  },
+  cardGrid: {
+    display: "flex",
+    gap: "20px",
+    flexWrap: "wrap",
+  },
+  emptyText: {
+    fontSize: "15px",
+    color: StudySessionColors.subtitle,
+    marginTop: "8px",
+  },
 };
 
 export default MyLibrary;

--- a/frontend/src/pages/StudyWorkspace.tsx
+++ b/frontend/src/pages/StudyWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Sidebar from "../components/layout/Sidebar";
 import { workspaceColors, StudySessionColors } from "../styles/colors";
 import {
@@ -7,25 +7,26 @@ import {
   generateFlashCards,
   generateKeyPoints,
 } from "../LLMServices/services/prompts";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import KeyPointsDisplay from "../components/study/KeyPointsDisplay";
 import SummaryDisplay from "../components/study/SummaryDisplay";
 import QuizDisplay from "../components/study/QuizDisplay";
 import FlashcardDisplay from "../components/study/FlashcardDisplay";
 import expandIcon from "../assets/expand.png";
 import collapseIcon from "../assets/collapse.png";
+import { getSession, updateSession } from "../utils/sessionStorage";
+import type { StudySession } from "../types/session";
 
 type TabType = "summary" | "quiz" | "flashcards" | "keypoints";
 
 const StudyWorkspace: React.FC = () => {
   const location = useLocation();
+  const navigate = useNavigate();
 
-  const { studyMaterial, sessionTitle } =
-    (location.state as {
-      studyMaterial?: string;
-      sessionTitle?: string;
-    }) || {};
+  const { sessionId } =
+    (location.state as { sessionId?: string }) || {};
 
+  const [session, setSession] = useState<StudySession | null>(null);
   const [activeTab, setActiveTab] = useState<TabType>("summary");
 
   const [outputs, setOutputs] = useState<Record<TabType, string>>({
@@ -37,39 +38,116 @@ const StudyWorkspace: React.FC = () => {
 
   const [loading, setLoading] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  // Load session on mount and restore outputs
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const loaded = getSession(sessionId);
+    if (!loaded) return;
+
+    setSession(loaded);
+    setOutputs({
+      summary: loaded.outputs.summary,
+      quiz: loaded.outputs.quiz,
+      flashcards: loaded.outputs.flashcards,
+      keypoints: loaded.outputs.keypoints,
+    });
+
+    // Update lastAccessedAt
+    updateSession(sessionId, { lastAccessedAt: Date.now() });
+  }, [sessionId]);
 
   const handleGenerate = async () => {
-    if (!studyMaterial) return;
+    if (!session?.studyMaterial) return;
 
     setLoading(true);
+    setErrorMsg("");
 
-    let result = "";
+    try {
+      let result = "";
 
-    if (activeTab === "summary") {
-      result = await generateSummary(studyMaterial);
-    } else if (activeTab === "quiz") {
-      result = await generateQuiz(studyMaterial);
-    } else if (activeTab === "flashcards") {
-      result = await generateFlashCards(studyMaterial);
-    } else if (activeTab === "keypoints") {
-      result = await generateKeyPoints(studyMaterial);
+      if (activeTab === "summary") {
+        result = await generateSummary(session.studyMaterial);
+      } else if (activeTab === "quiz") {
+        result = await generateQuiz(session.studyMaterial);
+      } else if (activeTab === "flashcards") {
+        result = await generateFlashCards(session.studyMaterial);
+      } else if (activeTab === "keypoints") {
+        result = await generateKeyPoints(session.studyMaterial);
+      }
+
+      setOutputs((prev) => ({ ...prev, [activeTab]: result }));
+
+      if (sessionId) {
+        updateSession(sessionId, {
+          outputs: { ...outputs, [activeTab]: result },
+          lastAccessedAt: Date.now(),
+        });
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "An error occurred while generating content.";
+      setErrorMsg(msg);
+    } finally {
+      setLoading(false);
     }
-
-    setOutputs((prev) => ({
-      ...prev,
-      [activeTab]: result,
-    }));
-
-    setLoading(false);
   };
+
+  const handleDone = () => {
+    if (sessionId) {
+      updateSession(sessionId, { isCompleted: true, lastAccessedAt: Date.now() });
+    }
+    navigate("/mylibrary");
+  };
+
+  // Fallback when no session ID was provided
+  if (!sessionId) {
+    return (
+      <div style={{ display: "flex", minHeight: "100vh" }}>
+        <Sidebar />
+        <div style={{ ...styles.main, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <div style={{ textAlign: "center" }}>
+            <h2 style={{ color: StudySessionColors.sectionTitle, marginBottom: 12 }}>
+              No session found
+            </h2>
+            <p style={{ color: StudySessionColors.subtitle, marginBottom: 24 }}>
+              Please create a new study session from the dashboard.
+            </p>
+            <button
+              style={styles.doneButton}
+              onClick={() => navigate("/studysession")}
+            >
+              Go to Study Session
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div style={{ display: "flex", minHeight: "100vh" }}>
       <Sidebar />
       <div style={styles.main}>
-        <div>
-          <h1 style={styles.title}>Study Workspace</h1>
-          <p style={styles.subtitle}>{sessionTitle || "Untitled Session"}</p>
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+          <div>
+            <h1 style={styles.title}>Study Workspace</h1>
+            <p style={styles.subtitle}>{session?.title || "Untitled Session"}</p>
+          </div>
+          <button
+            type="button"
+            style={styles.doneButton}
+            onClick={handleDone}
+            onMouseOver={(e) => {
+              e.currentTarget.style.backgroundColor = StudySessionColors.uploadButtonHover;
+            }}
+            onMouseOut={(e) => {
+              e.currentTarget.style.backgroundColor = StudySessionColors.uploadButtonBackground;
+            }}
+          >
+            Done
+          </button>
         </div>
 
         {/* Tabs */}
@@ -95,6 +173,11 @@ const StudyWorkspace: React.FC = () => {
             onClick={() => setActiveTab("flashcards")}
           />
         </div>
+
+        {/* Error message */}
+        {errorMsg && (
+          <p style={styles.errorText}>{errorMsg}</p>
+        )}
 
         {/* Output + Generate Button inside content box with overlay */}
         <div style={styles.relative}>
@@ -151,7 +234,6 @@ const StudyWorkspace: React.FC = () => {
         </div>
       </div>
     </div>
-    
   );
 };
 
@@ -180,171 +262,173 @@ const TabButton: React.FC<TabProps> = ({ label, active, onClick }) => {
   );
 };
 
-  const styles = {
-        relative: {
-          position: "relative" as const,
-        },
-        contentBoxDynamic: (isExpanded: boolean, hasOutput: string) => ({
-          ...styles.contentBox,
-          height: isExpanded ? "60vh" : "400px",
-          background: "linear-gradient(135deg, #f5f6fa 60%, #e3e6ee 100%)",
-          boxShadow: "0 10px 30px rgba(0,0,0,0.06)",
-          border: `1px solid ${StudySessionColors.cardBorder}`,
-          display: "flex",
-          flexDirection: "column" as const,
-          alignItems: "center",
-          justifyContent: hasOutput ? "flex-start" : "center",
-        }),
-        generateButtonDynamic: (loading: boolean) => ({
-          ...styles.generateButton,
-          backgroundColor: StudySessionColors.uploadButtonBackground,
-          color: StudySessionColors.uploadButtonText,
-          border: "none",
-          fontWeight: 600,
-          fontSize: "18px",
-          width: "auto",
-          minWidth: 220,
-          padding: "14px 32px",
-          borderRadius: "12px",
-          boxShadow: "0 2px 8px #0001",
-          cursor: loading ? "not-allowed" : "pointer",
-          margin: "0 auto",
-          marginBottom: "12px",
-          textAlign: "center" as const,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }),
-        overlay: {
-          position: "absolute" as const,
-          top: 0,
-          left: 0,
-          width: "100%",
-          height: "100%",
-          background: "rgba(200, 200, 210, 0.45)",
-          zIndex: 2,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          borderRadius: "16px",
-        },
-        overlayText: {
-          fontSize: 20,
-          color: StudySessionColors.sectionTitle,
-          fontWeight: 600,
-        },
-        outputBox: {
-          width: "100%",
-          height: "100%",
-        },
-        expandIconButton: {
-          position: "absolute" as const,
-          top: 18,
-          right: 18,
-          background: "#f5f6fa",
-          border: `1px solid ${StudySessionColors.cardBorder}`,
-          borderRadius: "50%",
-          width: 38,
-          height: 38,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          boxShadow: "0 2px 8px #0001",
-          cursor: "pointer",
-          zIndex: 3,
-          padding: 0,
-        },
-        expandIconImg: {
-          width: 22,
-          height: 22,
-          objectFit: "contain" as const,
-        },
-    title: {
-      fontSize: "32px",
-      marginBottom: "24px",
-      color: StudySessionColors.title,
-      textAlign: "left" as const,
-    },
-
-    subtitle: {
-      fontSize: "18px",
-      marginBottom: "24px",
-      color: StudySessionColors.subtitle,
-      textAlign: "left" as const,
-    },
-  
-    main: {
-      flex: 1,
-      padding: "40px",
-      background: `linear-gradient(135deg, ${StudySessionColors.pageGradientStart}, ${StudySessionColors.pageGradientEnd})`,
-    },
-  
-    tabs: {
-      display: "flex",
-      gap: "16px",
-      backgroundColor: workspaceColors.tabBackground,
-      padding: "12px",
-      borderRadius: "12px",
-      marginTop: "20px",
-
-      width: "100%",
-      maxWidth: "700px",
-      marginLeft: "auto",
-      marginRight: "auto",
-
-      justifyContent: "space-between" as const,
-    },
-  
-    tabButton: {
-      flex: 1,
-      padding: "12px 0",
-      borderRadius: "10px",
-      border: "none",
-      cursor: "pointer",
-      fontWeight: 600,
-      color: StudySessionColors.sectionTitle,
-      transition: "all 0.2s ease",
-    },
-  
-    contentBox: {
-      marginTop: "30px",
-      border: `1px solid ${StudySessionColors.cardBorder}`,
-      borderRadius: "16px",
-      height: "400px",
-      maxHeight: "80vh",
-      display: "flex",
-      justifyContent: "flex-start" as const,
-      alignItems: "flex-start" as const,
-      backgroundColor: StudySessionColors.cardBackground,
-      boxShadow: "0 10px 30px rgba(0,0,0,0.06)",
-      padding: "20px",
-      overflowY: "auto" as const,
-      transition: "height 0.3s ease",
-    },
-  
-    contentText: {
-      fontSize: "18px",
-      color: StudySessionColors.textareaText,
-      width: "100%",
-      whiteSpace: "pre-wrap" as const,
-      textAlign: "left" as const,
-    },
-    generateButton: {
-      justifyContent: "center" as const,
-      marginTop: "20px",
-      borderRadius: "12px",
-      height: "40px",
-      width: "170px",
-      fontSize: "16px",
-      backgroundColor: workspaceColors.generateButtonBackground,
-    },
-    expandButton: {
-      marginTop: "20px",
-      padding: "8px 14px",
-      borderRadius: "10px",
-      border: "none",
-      cursor: "pointer",
-      backgroundColor: workspaceColors.generateButtonBackground,
-      fontWeight: 600,
-    },
-  };
+const styles = {
+  relative: {
+    position: "relative" as const,
+  },
+  contentBoxDynamic: (isExpanded: boolean, hasOutput: string) => ({
+    ...styles.contentBox,
+    height: isExpanded ? "60vh" : "400px",
+    background: "linear-gradient(135deg, #f5f6fa 60%, #e3e6ee 100%)",
+    boxShadow: "0 10px 30px rgba(0,0,0,0.06)",
+    border: `1px solid ${StudySessionColors.cardBorder}`,
+    display: "flex",
+    flexDirection: "column" as const,
+    alignItems: "center",
+    justifyContent: hasOutput ? "flex-start" : "center",
+  }),
+  generateButtonDynamic: (loading: boolean) => ({
+    ...styles.generateButton,
+    backgroundColor: StudySessionColors.uploadButtonBackground,
+    color: StudySessionColors.uploadButtonText,
+    border: "none",
+    fontWeight: 600,
+    fontSize: "18px",
+    width: "auto",
+    minWidth: 220,
+    padding: "14px 32px",
+    borderRadius: "12px",
+    boxShadow: "0 2px 8px #0001",
+    cursor: loading ? "not-allowed" : "pointer",
+    margin: "0 auto",
+    marginBottom: "12px",
+    textAlign: "center" as const,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  }),
+  overlay: {
+    position: "absolute" as const,
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    background: "rgba(200, 200, 210, 0.45)",
+    zIndex: 2,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: "16px",
+  },
+  overlayText: {
+    fontSize: 20,
+    color: StudySessionColors.sectionTitle,
+    fontWeight: 600,
+  },
+  outputBox: {
+    width: "100%",
+    height: "100%",
+  },
+  expandIconButton: {
+    position: "absolute" as const,
+    top: 18,
+    right: 18,
+    background: "#f5f6fa",
+    border: `1px solid ${StudySessionColors.cardBorder}`,
+    borderRadius: "50%",
+    width: 38,
+    height: 38,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    boxShadow: "0 2px 8px #0001",
+    cursor: "pointer",
+    zIndex: 3,
+    padding: 0,
+  },
+  expandIconImg: {
+    width: 22,
+    height: 22,
+    objectFit: "contain" as const,
+  },
+  doneButton: {
+    padding: "10px 24px",
+    borderRadius: 12,
+    border: "none",
+    backgroundColor: StudySessionColors.uploadButtonBackground,
+    color: StudySessionColors.uploadButtonText,
+    fontWeight: 600,
+    fontSize: 15,
+    cursor: "pointer",
+    transition: "background-color 0.15s ease",
+    boxShadow: "0 4px 18px rgba(0, 122, 255, 0.22)",
+    marginTop: 8,
+  },
+  errorText: {
+    color: StudySessionColors.deleteButtonText,
+    fontSize: 14,
+    marginTop: 12,
+    marginBottom: 0,
+  },
+  title: {
+    fontSize: "32px",
+    marginBottom: "24px",
+    color: StudySessionColors.title,
+    textAlign: "left" as const,
+  },
+  subtitle: {
+    fontSize: "18px",
+    marginBottom: "24px",
+    color: StudySessionColors.subtitle,
+    textAlign: "left" as const,
+  },
+  main: {
+    flex: 1,
+    padding: "40px",
+    background: `linear-gradient(135deg, ${StudySessionColors.pageGradientStart}, ${StudySessionColors.pageGradientEnd})`,
+  },
+  tabs: {
+    display: "flex",
+    gap: "16px",
+    backgroundColor: workspaceColors.tabBackground,
+    padding: "12px",
+    borderRadius: "12px",
+    marginTop: "20px",
+    width: "100%",
+    maxWidth: "700px",
+    marginLeft: "auto",
+    marginRight: "auto",
+    justifyContent: "space-between" as const,
+  },
+  tabButton: {
+    flex: 1,
+    padding: "12px 0",
+    borderRadius: "10px",
+    border: "none",
+    cursor: "pointer",
+    fontWeight: 600,
+    color: StudySessionColors.sectionTitle,
+    transition: "all 0.2s ease",
+  },
+  contentBox: {
+    marginTop: "30px",
+    border: `1px solid ${StudySessionColors.cardBorder}`,
+    borderRadius: "16px",
+    height: "400px",
+    maxHeight: "80vh",
+    display: "flex",
+    justifyContent: "flex-start" as const,
+    alignItems: "flex-start" as const,
+    backgroundColor: StudySessionColors.cardBackground,
+    boxShadow: "0 10px 30px rgba(0,0,0,0.06)",
+    padding: "20px",
+    overflowY: "auto" as const,
+    transition: "height 0.3s ease",
+  },
+  contentText: {
+    fontSize: "18px",
+    color: StudySessionColors.textareaText,
+    width: "100%",
+    whiteSpace: "pre-wrap" as const,
+    textAlign: "left" as const,
+  },
+  generateButton: {
+    justifyContent: "center" as const,
+    marginTop: "20px",
+    borderRadius: "12px",
+    height: "40px",
+    width: "170px",
+    fontSize: "16px",
+    backgroundColor: workspaceColors.generateButtonBackground,
+  },
+};

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -1,0 +1,14 @@
+export interface StudySession {
+  id: string;
+  title: string;
+  studyMaterial: string;
+  outputs: {
+    summary: string;
+    quiz: string;
+    flashcards: string;
+    keypoints: string;
+  };
+  createdAt: number;
+  lastAccessedAt: number;
+  isCompleted: boolean;
+}

--- a/frontend/src/utils/sessionStorage.ts
+++ b/frontend/src/utils/sessionStorage.ts
@@ -1,0 +1,50 @@
+import type { StudySession } from "../types/session";
+
+const STORAGE_KEY = "gogofast_sessions";
+
+export function getSessions(): StudySession[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as StudySession[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getSession(id: string): StudySession | null {
+  return getSessions().find((s) => s.id === id) ?? null;
+}
+
+export function saveSession(session: StudySession): void {
+  const sessions = getSessions().filter((s) => s.id !== session.id);
+  sessions.push(session);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+}
+
+export function updateSession(
+  id: string,
+  updates: Partial<Omit<StudySession, "id">>
+): void {
+  const sessions = getSessions().map((s) =>
+    s.id === id ? { ...s, ...updates } : s
+  );
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+}
+
+export function createSessionId(): string {
+  return `session_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export function formatLastAccessed(timestamp: number): string {
+  const diffMs = Date.now() - timestamp;
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return "just now";
+  if (diffMin < 60) return `${diffMin} min ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay === 1) return "Yesterday";
+  return `${diffDay} days ago`;
+}


### PR DESCRIPTION
Implement study sessions (Issue #5) and library page (Issue #6 & #7)
- Add session.ts: StudySession interface with id, title, studyMaterial, outputs, createdAt, lastAccessedAt, isCompleted
- Add sessionStorage.ts: localStorage helpers (getSessions, getSession, saveSession, updateSession, createSessionId, formatLastAccessed)
- GenerateStudySessionCard: create and persist a real StudySession before navigating; pass sessionId via router state instead of raw content
- StudyCard: accepts a session prop, displays real title and last-accessed time, navigates to workspace by sessionId
- ContinueStudyingSection: reads sessions from localStorage on mount, sorts by lastAccessedAt, shows up to 4 non-completed sessions with empty-state message
- StudyWorkspace: loads session by sessionId, restores previously generated outputs, persists outputs after each generation, updates lastAccessedAt on visit; adds Done button that marks session completed and redirects to mylibrary; wraps all generation calls in try/catch/finally to fix the locked-button bug on Groq API errors; adds graceful no-session fallback UI
- MyLibrary: reads completed sessions from localStorage, renders StudyCard grid, matches Dashboard layout and gradient, shows empty-state when no sessions